### PR TITLE
Blacklist eco

### DIFF
--- a/contracts.json
+++ b/contracts.json
@@ -14,7 +14,8 @@
         "v3": "0xd068b1F6F0623CbCC7ADC7545290f8991C9B8Ec9",
         "v4": "0x891021b34fedc18e36c015bffaa64a2421738906",
         "Bv4": "0xD605357aBbAF57d118c8DeDf6F2d71aEFa3ba9c5",
-        "v5": "0x690481Ce72b1080Bd928A35A0ECF329BE902cD6a"
+        "v5": "0x690481Ce72b1080Bd928A35A0ECF329BE902cD6a",
+        "v4.2": "0xb9FE57efA135A5feC7bfeB5fdf2B3910E6f5703A"
     },
     "17000": {
         "name": "ethereum holesky testnet",
@@ -28,7 +29,8 @@
         "mainnet": "false",
         "v4": "0x897F8EDdB345F0d16081615823F76055Ad60A00c",
         "Bv4": "0x1851359AB8B002217cf4D108d7F027B63563754C",
-        "v5": "0x690481Ce72b1080Bd928A35A0ECF329BE902cD6a"
+        "v5": "0x690481Ce72b1080Bd928A35A0ECF329BE902cD6a",
+        "v4.2": "0x661c60E5f5104C43AF764176B0B0a70616F79C6b"
     },
     "137": {
         "name": "polygon-mainnet",

--- a/deploy.py
+++ b/deploy.py
@@ -13,7 +13,13 @@ dotenv.load_dotenv()
 config = toml.load("foundry.toml")
 
 # Definitions
-CONTRACTS_MAPPING = {"PeanutV3": "v3", "PeanutV4": "v4", "PeanutBatcherV4": "Bv4", "PeanutV5": "v5"}
+CONTRACTS_MAPPING = {
+    "PeanutV3": "v3",
+    "PeanutV4": "v4",
+    "PeanutV4.2": "v4.2",
+    "PeanutBatcherV4": "Bv4",
+    "PeanutV5": "v5",
+}
 CONTRACTS = list(CONTRACTS_MAPPING.keys())
 CONTRACTS_JSON_PATH = "contracts.json"
 

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,3 +1,3 @@
-@openzeppelin=lib/openzeppelin-contracts # v4.9.2
+@openzeppelin=lib/openzeppelin-contracts
 @helix-foundation=lib/currency
 @forge-std=lib/forge-std/src

--- a/script/DeploymentGlobals.sol
+++ b/script/DeploymentGlobals.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.20;
+
+import "forge-std/Script.sol";
+import "../src/V4/PeanutV4.sol";
+
+contract DeploymentGlobals {
+    mapping(uint256 => address) public ecoAddressByChain;
+
+    constructor() {
+        // Mainnet and its testnets
+        ecoAddressByChain[1] = 0x8dBF9A4c99580fC7Fd4024ee08f3994420035727;
+        ecoAddressByChain[5] = 0x8dBF9A4c99580fC7Fd4024ee08f3994420035727;
+        ecoAddressByChain[11155111] = 0x8dBF9A4c99580fC7Fd4024ee08f3994420035727;
+        ecoAddressByChain[17000] = 0x8dBF9A4c99580fC7Fd4024ee08f3994420035727;
+
+        // Optimism and its goerli
+        ecoAddressByChain[10] = 0xe7BC9b3A936F122f08AAC3b1fac3C3eC29A78874;
+        ecoAddressByChain[420] = 0xe7BC9b3A936F122f08AAC3b1fac3C3eC29A78874;
+    }
+}

--- a/script/PeanutV4.2.s.sol
+++ b/script/PeanutV4.2.s.sol
@@ -3,14 +3,17 @@ pragma solidity ^0.8.20;
 
 import "forge-std/Script.sol";
 import "../src/V4/PeanutV4.sol";
+import "./DeploymentGlobals.sol";
 
-contract DeployScript is Script {
+contract DeployScript is Script, DeploymentGlobals {
     function run() external {
         uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
         vm.startBroadcast(deployerPrivateKey);
 
+        address ecoAddress = ecoAddressByChain[block.chainid];
+
         // Create new peanut contract (with broadcast enabled this will send the tx to mempool)
-        PeanutV4 peanutV4 = new PeanutV4(address(0));
+        PeanutV4 peanutV4 = new PeanutV4(ecoAddress);
 
         vm.stopBroadcast();
 

--- a/script/PeanutV5.s.sol
+++ b/script/PeanutV5.s.sol
@@ -3,8 +3,9 @@ pragma solidity ^0.8.20;
 
 import "forge-std/Script.sol";
 import "../src/V5/PeanutV5.sol";
+import "./DeploymentGlobals.sol";
 
-contract DeployScript is Script {
+contract DeployScript is Script, DeploymentGlobals {
     function run() external {
         uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
         vm.startBroadcast(deployerPrivateKey);
@@ -25,8 +26,10 @@ contract DeployScript is Script {
         );
         console.log("target address: %s", address(targetAddress));
 
+        address ecoAddress = ecoAddressByChain[block.chainid];
+
         // Deploy the contract using CREATE2
-        PeanutV5 peanutV5 = new PeanutV5{salt: salt}();
+        PeanutV5 peanutV5 = new PeanutV5{salt: salt}(ecoAddress);
         // PeanutV5 peanutV5 = new PeanutV5();
 
         vm.stopBroadcast();

--- a/src/V4/PeanutV4.sol
+++ b/src/V4/PeanutV4.sol
@@ -8,7 +8,7 @@ pragma solidity ^0.8.19;
 //          Links use asymmetric ECDSA encryption by default to be secure & enable trustless,
 //          gasless claiming.
 //          more at: https://peanut.to
-// @version 0.4.1
+// @version 0.4.2
 // @author  H & K
 //////////////////////////////////////////////////////////////////////////////////////
 //⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
@@ -53,6 +53,7 @@ contract PeanutV4 is IERC721Receiver, IERC1155Receiver, ReentrancyGuard {
     }
 
     Deposit[] public deposits; // array of deposits
+    address public ecoAddress; // address of the ECO token
 
     // events
     event DepositEvent(
@@ -63,9 +64,11 @@ contract PeanutV4 is IERC721Receiver, IERC1155Receiver, ReentrancyGuard {
     );
     event MessageEvent(string message);
 
-    // constructor
-    constructor() {
+    // constructor. Accepts ECO token address to prohibit ECO usage in normal
+    // ERC20 deposits.
+    constructor(address _ecoAddress) {
         emit MessageEvent("Hello World, have a nutty day!");
+        ecoAddress = _ecoAddress;
     }
 
     /**
@@ -109,6 +112,10 @@ contract PeanutV4 is IERC721Receiver, IERC1155Receiver, ReentrancyGuard {
             // REMINDER: User must approve this contract to spend the tokens before calling this function
             // Unfortunately there's no way of doing this in just one transaction.
             // Wallet abstraction pls
+
+            // If ECO is deposited as a normal ERC20 and then inflation is increased,
+            // the recipient would get more tokens than what was deposited.
+            require(_tokenAddress != ecoAddress, "ECO DEPOSITS MUST USE _contractType 4");
 
             IERC20 token = IERC20(_tokenAddress);
 

--- a/src/V5/PeanutV5.sol
+++ b/src/V5/PeanutV5.sol
@@ -55,6 +55,7 @@ contract PeanutV5 is IERC721Receiver, IERC1155Receiver, ReentrancyGuard {
     }
 
     Deposit[] public deposits; // array of deposits
+    address public ecoAddress; // address of the ECO token
 
     // events
     event DepositEvent(
@@ -73,9 +74,11 @@ contract PeanutV5 is IERC721Receiver, IERC1155Receiver, ReentrancyGuard {
     );
     event MessageEvent(string message);
 
-    // constructor
-    constructor() {
+    // constructor. Accepts ECO token address to prohibit ECO usage in normal
+    // ERC20 deposits.
+    constructor(address _ecoAddress) {
         emit MessageEvent("Hello World, have a nutty day!");
+        ecoAddress = _ecoAddress;
     }
 
     /**
@@ -119,6 +122,10 @@ contract PeanutV5 is IERC721Receiver, IERC1155Receiver, ReentrancyGuard {
             // REMINDER: User must approve this contract to spend the tokens before calling this function
             // Unfortunately there's no way of doing this in just one transaction.
             // Wallet abstraction pls
+
+            // If ECO is deposited as a normal ERC20 and then inflation is increased,
+            // the recipient would get more tokens than what was deposited.
+            require(_tokenAddress != ecoAddress, "ECO DEPOSITS MUST USE _contractType 4");
 
             IERC20 token = IERC20(_tokenAddress);
 

--- a/src/V5/PeanutV5.sol
+++ b/src/V5/PeanutV5.sol
@@ -553,15 +553,23 @@ contract PeanutV5 is IERC721Receiver, IERC1155Receiver, ReentrancyGuard {
      * @return Deposit[] array of deposits
      */
     function getAllDepositsForAddress(address _address) external view returns (Deposit[] memory) {
-        Deposit[] memory _deposits = new Deposit[](deposits.length);
         uint256 count = 0;
+        for (uint256 i = 0; i < deposits.length; i++) {
+            if (deposits[i].senderAddress == _address) {
+                count++;
+            }
+        }
+
+        Deposit[] memory _deposits = new Deposit[](count);
+
+        count = 0;
+        // Second loop to populate the array
         for (uint256 i = 0; i < deposits.length; i++) {
             if (deposits[i].senderAddress == _address) {
                 _deposits[count] = deposits[i];
                 count++;
             }
         }
-        // TODO: should also return deposit idx
         return _deposits;
     }
 

--- a/test/V4/Batch/testBatchDeposit.sol
+++ b/test/V4/Batch/testBatchDeposit.sol
@@ -20,7 +20,7 @@ pragma solidity ^0.8.0;
 
 //     function setUp() public {
 //         console.log("Setting up test");
-//         peanutV4 = new PeanutV4();
+//         peanutV4 = new PeanutV4(address(0));
 //         testToken = new ERC20Mock();
 //         testToken721 = new ERC721Mock();
 //         // testToken1155 = new ERC1155Mock();

--- a/test/V4/Batch/testBatchDepositEther.sol
+++ b/test/V4/Batch/testBatchDepositEther.sol
@@ -20,7 +20,7 @@ pragma solidity ^0.8.0;
 
 //     function setUp() public {
 //         console.log("Setting up test");
-//         peanutV4 = new PeanutV4();
+//         peanutV4 = new PeanutV4(address(0));
 //         testToken = new ERC20Mock();
 //         testToken721 = new ERC721Mock();
 //         // testToken1155 = new ERC1155Mock();

--- a/test/V4/Batch/testBatchDepositEtherOptimized.sol
+++ b/test/V4/Batch/testBatchDepositEtherOptimized.sol
@@ -20,7 +20,7 @@ pragma solidity ^0.8.0;
 
 //     function setUp() public {
 //         console.log("Setting up test");
-//         peanutV4 = new PeanutV4();
+//         peanutV4 = new PeanutV4(address(0));
 //         testToken = new ERC20Mock();
 //         testToken721 = new ERC721Mock();
 //         // testToken1155 = new ERC1155Mock();

--- a/test/V4/PeanutBatcher.t.sol
+++ b/test/V4/PeanutBatcher.t.sol
@@ -20,7 +20,7 @@ contract PeanutBatcherTest is Test, ERC1155Holder, ERC721Holder {
 
     function setUp() public {
         batcher = new PeanutBatcherV4();
-        peanutV4 = new PeanutV4();
+        peanutV4 = new PeanutV4(address(0));
         testToken = new ERC20Mock();
         testToken721 = new ERC721Mock();
         testToken1155 = new ERC1155Mock();

--- a/test/V4/PeanutV4.t.sol
+++ b/test/V4/PeanutV4.t.sol
@@ -19,10 +19,10 @@ contract PeanutV4Test is Test {
 
     function setUp() public {
         console.log("Setting up test");
-        peanutV4 = new PeanutV4();
         testToken = new ERC20Mock();
         testToken721 = new ERC721Mock();
         testToken1155 = new ERC1155Mock();
+        peanutV4 = new PeanutV4(address(0));
 
         // Mint tokens for test accounts
         testToken.mint(address(this), 1000);
@@ -47,6 +47,20 @@ contract PeanutV4Test is Test {
 
         assertEq(depositIndex, 0, "Deposit failed");
         assertEq(peanutV4.getDepositCount(), 1, "Deposit count mismatch");
+    }
+
+    // If we attempt to deposit ECO tokens as pure ERC20s (i.e. with _contractType = 1),
+    // makeDeposit function must revert.
+    function testECOMaliciousDeposit() public {
+        // pretent that testToken is ECO
+        PeanutV4 peanutV4ECO = new PeanutV4(address(testToken));
+
+        // approve tokens to be spent by the new peanut instance
+        testToken.approve(address(peanutV4), 1000);
+
+        // Test!!!!!!!!
+        vm.expectRevert("ECO DEPOSITS MUST USE _contractType 4");
+        peanutV4ECO.makeDeposit(address(testToken), 1, 100, 0, address(0));
     }
 
     function testMakeDepositERC721() public {

--- a/test/V4/testBatch.sol
+++ b/test/V4/testBatch.sol
@@ -20,7 +20,7 @@ pragma solidity ^0.8.0;
 
 //     function setUp() public {
 //         console.log("Setting up test");
-//         peanutV4 = new PeanutV4();
+//         peanutV4 = new PeanutV4(address(0));
 //         testToken = new ERC20Mock();
 //         testToken721 = new ERC721Mock();
 //         // testToken1155 = new ERC1155Mock();

--- a/test/V4/testDeposit.sol
+++ b/test/V4/testDeposit.sol
@@ -25,7 +25,7 @@ contract PeanutV4Test is Test, ERC1155Holder, ERC721Holder {
 
     function setUp() public {
         console.log("Setting up test");
-        peanutV4 = new PeanutV4();
+        peanutV4 = new PeanutV4(address(0));
         testToken = new ERC20Mock();
         testToken721 = new ERC721Mock();
         testToken1155 = new ERC1155Mock();

--- a/test/V4/testDirectTransfer.sol
+++ b/test/V4/testDirectTransfer.sol
@@ -21,7 +21,7 @@ contract PeanutV4Test is Test, ERC1155Holder, ERC721Holder {
 
     function setUp() public {
         console.log("Setting up test");
-        peanutV4 = new PeanutV4();
+        peanutV4 = new PeanutV4(address(0));
         testToken = new ERC20Mock();
         testToken721 = new ERC721Mock();
         testToken1155 = new ERC1155Mock();

--- a/test/V4/testIntegration.sol
+++ b/test/V4/testIntegration.sol
@@ -25,7 +25,7 @@ contract PeanutV4Test is Test, ERC1155Holder, ERC721Holder {
 
     function setUp() public {
         console.log("Setting up test");
-        peanutV4 = new PeanutV4();
+        peanutV4 = new PeanutV4(address(0));
         testToken = new ERC20Mock();
         testToken721 = new ERC721Mock();
         testToken1155 = new ERC1155Mock();

--- a/test/V4/testSenderWithdraw.sol
+++ b/test/V4/testSenderWithdraw.sol
@@ -19,7 +19,7 @@ contract TestSenderWithdrawEther is Test {
 
     function setUp() public {
         console.log("Setting up test");
-        peanutV4 = new PeanutV4();
+        peanutV4 = new PeanutV4(address(0));
     }
 
     // test sender withdrawal of ERC20
@@ -67,7 +67,7 @@ contract TestSenderWithdrawErc20 is Test {
     // apparently not possible to fuzz test in setUp() function?
     function setUp() public {
         console.log("Setting up test");
-        peanutV4 = new PeanutV4();
+        peanutV4 = new PeanutV4(address(0));
         testToken = new ERC20Mock(); // contractype 1
 
         // Mint tokens for test accounts (larger than uint128)
@@ -118,7 +118,7 @@ contract TestSenderWithdrawErc721 is Test, ERC721Holder {
     // apparently not possible to fuzz test in setUp() function?
     function setUp() public {
         console.log("Setting up test");
-        peanutV4 = new PeanutV4();
+        peanutV4 = new PeanutV4(address(0));
         testToken = new ERC721Mock(); // contractype 2
 
         // Mint token for test
@@ -169,7 +169,7 @@ contract TestSenderWithdrawErc1155 is Test, ERC1155Holder {
     // apparently not possible to fuzz test in setUp() function?
     function setUp() public {
         console.log("Setting up test");
-        peanutV4 = new PeanutV4();
+        peanutV4 = new PeanutV4(address(0));
         testToken = new ERC1155Mock(); // contractype 3
 
         // Mint tokens for test

--- a/test/V4/testSigWithdraw.sol
+++ b/test/V4/testSigWithdraw.sol
@@ -25,7 +25,7 @@ contract TestSigWithdrawEther is Test {
 
     function setUp() public {
         console.log("Setting up test");
-        peanutV4 = new PeanutV4();
+        peanutV4 = new PeanutV4(address(0));
     }
 
     // test sender withdrawal of ERC20

--- a/test/V5/PeanutV5.t.sol
+++ b/test/V5/PeanutV5.t.sol
@@ -19,7 +19,7 @@ contract PeanutV5Test is Test {
 
     function setUp() public {
         console.log("Setting up test");
-        peanutV5 = new PeanutV5();
+        peanutV5 = new PeanutV5(address(0));
         testToken = new ERC20Mock();
         testToken721 = new ERC721Mock();
         testToken1155 = new ERC1155Mock();
@@ -47,6 +47,20 @@ contract PeanutV5Test is Test {
 
         assertEq(depositIndex, 0, "Deposit failed");
         assertEq(peanutV5.getDepositCount(), 1, "Deposit count mismatch");
+    }
+
+    // If we attempt to deposit ECO tokens as pure ERC20s (i.e. with _contractType = 1),
+    // makeDeposit function must revert.
+    function testECOMaliciousDeposit() public {
+        // pretent that testToken is ECO
+        PeanutV5 peanutV5ECO = new PeanutV5(address(testToken));
+
+        // approve tokens to be spent by the new peanut instance
+        testToken.approve(address(peanutV5), 1000);
+
+        // Test!!!!!!!!
+        vm.expectRevert("ECO DEPOSITS MUST USE _contractType 4");
+        peanutV5ECO.makeDeposit(address(testToken), 1, 100, 0, address(0));
     }
 
     function testMakeDepositERC721() public {

--- a/test/V5/testDeposit.sol
+++ b/test/V5/testDeposit.sol
@@ -25,7 +25,7 @@ contract PeanutV5Test is Test, ERC1155Holder, ERC721Holder {
 
     function setUp() public {
         console.log("Setting up test");
-        peanutV5 = new PeanutV5();
+        peanutV5 = new PeanutV5(address(0));
         testToken = new ERC20Mock();
         testToken721 = new ERC721Mock();
         testToken1155 = new ERC1155Mock();

--- a/test/V5/testDirectTransfer.sol
+++ b/test/V5/testDirectTransfer.sol
@@ -21,7 +21,7 @@ contract PeanutV5Test is Test, ERC1155Holder, ERC721Holder {
 
     function setUp() public {
         console.log("Setting up test");
-        peanutV5 = new PeanutV5();
+        peanutV5 = new PeanutV5(address(0));
         testToken = new ERC20Mock();
         testToken721 = new ERC721Mock();
         testToken1155 = new ERC1155Mock();

--- a/test/V5/testIntegration.sol
+++ b/test/V5/testIntegration.sol
@@ -25,7 +25,7 @@ contract PeanutV5Test is Test, ERC1155Holder, ERC721Holder {
 
     function setUp() public {
         console.log("Setting up test");
-        peanutV5 = new PeanutV5();
+        peanutV5 = new PeanutV5(address(0));
         testToken = new ERC20Mock();
         testToken721 = new ERC721Mock();
         testToken1155 = new ERC1155Mock();

--- a/test/V5/testSenderWithdraw.sol
+++ b/test/V5/testSenderWithdraw.sol
@@ -19,7 +19,7 @@ contract TestSenderWithdrawEther is Test {
 
     function setUp() public {
         console.log("Setting up test");
-        peanutV5 = new PeanutV5();
+        peanutV5 = new PeanutV5(address(0));
     }
 
     // test sender withdrawal of ERC20
@@ -67,7 +67,7 @@ contract TestSenderWithdrawErc20 is Test {
     // apparently not possible to fuzz test in setUp() function?
     function setUp() public {
         console.log("Setting up test");
-        peanutV5 = new PeanutV5();
+        peanutV5 = new PeanutV5(address(0));
         testToken = new ERC20Mock(); // contractype 1
 
         // Mint tokens for test accounts (larger than uint128)
@@ -118,7 +118,7 @@ contract TestSenderWithdrawErc721 is Test, ERC721Holder {
     // apparently not possible to fuzz test in setUp() function?
     function setUp() public {
         console.log("Setting up test");
-        peanutV5 = new PeanutV5();
+        peanutV5 = new PeanutV5(address(0));
         testToken = new ERC721Mock(); // contractype 2
 
         // Mint token for test
@@ -169,7 +169,7 @@ contract TestSenderWithdrawErc1155 is Test, ERC1155Holder {
     // apparently not possible to fuzz test in setUp() function?
     function setUp() public {
         console.log("Setting up test");
-        peanutV5 = new PeanutV5();
+        peanutV5 = new PeanutV5(address(0));
         testToken = new ERC1155Mock(); // contractype 3
 
         // Mint tokens for test

--- a/test/V5/testSigWithdraw.sol
+++ b/test/V5/testSigWithdraw.sol
@@ -25,7 +25,7 @@ contract TestSigWithdrawEther is Test {
 
     function setUp() public {
         console.log("Setting up test");
-        peanutV5 = new PeanutV5();
+        peanutV5 = new PeanutV5(address(0));
     }
 
     // test sender withdrawal of ERC20

--- a/test/V5/testWithdrawDepositXChain.sol
+++ b/test/V5/testWithdrawDepositXChain.sol
@@ -66,7 +66,7 @@ contract TestClaimXChainNonForked is Test {
 
     function setUp() public {
         console.log("Setting up test TestClaimXChainNonForked");
-        peanutV5 = new PeanutV5();
+        peanutV5 = new PeanutV5(address(0));
 
         peanutV5.makeDeposit{value: DEPOSIT_AMOUNT}(SENDER_ADDRESS, 0, DEPOSIT_AMOUNT, 0, PUBKEY20);
     }


### PR DESCRIPTION
Prohibits ECO tokens from being used in pure ERC20 deposits.

Updates the contracts (V4 and V5) and deployment scripts.

Also fixes `remappings.txt` and adjusts `Peanut V5`'s `getAllDepositsForAddress` function.